### PR TITLE
minor ubuntu update, chef 11, and VPC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.1.3)
+    CFPropertyList (2.3.1)
+    builder (3.2.2)
     chef (11.6.2)
       erubis (~> 2.7)
       highline (~> 1.6, >= 1.6.9)
@@ -17,19 +18,106 @@ GEM
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
     erubis (2.7.0)
-    excon (0.16.2)
-    fog (1.6.0)
+    excon (0.45.3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.31.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.30)
+      fog-ecloud
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.6.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.31.1)
       builder
-      excon (~> 0.14)
-      formatador (~> 0.2.0)
+      excon (~> 0.45)
+      formatador (~> 0.2)
       mime-types
-      multi_json (~> 1.0)
-      net-scp (~> 1.0.4)
+      net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5.0)
-      ruby-hmac
-    formatador (0.2.3)
+    fog-ecloud (0.2.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.6)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.3)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
     highline (1.6.21)
+    inflecto (0.0.2)
     ipaddress (0.8.0)
     json (1.7.7)
     librarian (0.1.2)
@@ -39,7 +127,8 @@ GEM
       chef (>= 0.10)
       librarian (~> 0.1.0)
       minitar (>= 0.5.2)
-    mime-types (2.3)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
     minitar (0.5.4)
     mixlib-authentication (1.3.0)
       mixlib-log
@@ -47,16 +136,17 @@ GEM
     mixlib-config (1.1.2)
     mixlib-log (1.6.0)
     mixlib-shellout (1.4.0)
-    multi_json (1.3.6)
-    net-scp (1.0.4)
-      net-ssh (>= 1.99.1)
-    net-ssh (2.9.1)
+    multi_json (1.11.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.1)
       net-ssh (>= 2.1.4)
       net-ssh-gateway (>= 0.99.0)
-    nokogiri (1.5.5)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     ohai (6.22.0)
       ipaddress
       mixlib-cli
@@ -67,7 +157,6 @@ GEM
       yajl-ruby
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    ruby-hmac (0.4.0)
     systemu (2.5.2)
     thor (0.19.1)
     trollop (2.0)

--- a/aws-config/defaults.json
+++ b/aws-config/defaults.json
@@ -1,9 +1,11 @@
 {
-  "availability_zone": "us-east-1e",
+  "availability_zone": "us-east-1c",
   "db_engine_version": "5.5",
   "db_flavor_id": "db.m1.small",
   "db_allocated_storage": "12",
   "ec2_key_name": "genigames",
-  "ec2_image_id": "ami-0721ac6e",
-  "ec2_flavor_id": "c1.medium"
+  "ec2_image_id": "ami-61e51f0a",
+  "ec2_flavor_id": "c3.large",
+  "vpc_id": "vpc-9c9714f9",
+  "subnet_id": "subnet-7fb16326"
 }

--- a/script/create_ec2.rb
+++ b/script/create_ec2.rb
@@ -21,8 +21,9 @@ Trollop::die :project, "is required" unless options[:project]
 
 config = aws_config(options[:project])
 
-find_or_create_ec2_security_group(
+security_group = find_or_create_ec2_security_group(
   name:        options[:project],
+  vpc_id:      config['vpc_id'],
   description: "#{options[:project]} security group"
 )
 
@@ -31,7 +32,8 @@ create_ec2_instance(
   image_id:          config['ec2_image_id'],
   flavor_id:         config['ec2_flavor_id'],
   availability_zone: config['availability_zone'],
-  groups:            options[:project],
+  subnet_id:         config['subnet_id'],
+  security_group_ids: [security_group.group_id],
   tags: {
     "Name"     => "#{options[:project]}-#{options[:stage]}",
     "Contacts" => options[:contact],

--- a/script/lib/aws_config.rb
+++ b/script/lib/aws_config.rb
@@ -1,11 +1,15 @@
 require 'json'
 
 def aws_config(project)
-  default_config = JSON.load File.new("aws-config/defaults.json")
+  default_config = aws_config_defaults
   if File.exists? "aws-config/#{project}.json"
     proj_config = JSON.load File.new("aws-config/#{project}.json")
     default_config.merge(proj_config)
   else
     default_config
   end
+end
+
+def aws_config_defaults
+  JSON.load File.new("aws-config/defaults.json")
 end

--- a/script/lib/ec2_helpers.rb
+++ b/script/lib/ec2_helpers.rb
@@ -44,8 +44,9 @@ def find_or_create_ec2_security_group(options)
   # we also (unfortunately) seem to have unnamed security groups now?
   # can't find the security group with nil name in the AWS console...
   ec2_sec_group = ec2.security_groups.find do |sg| 
-    return false unless sg.name
-    return true if (sg.name.downcase == options[:name].downcase)
+      sg.name &&
+      (sg.name.downcase == options[:name].downcase) &&
+      (sg.vpc_id == options[:vpc_id])
   end
 
   unless ec2_sec_group
@@ -54,4 +55,6 @@ def find_or_create_ec2_security_group(options)
     ec2_sec_group.authorize_port_range(80..80)
     ec2_sec_group.authorize_port_range(443..443)
   end
+
+  ec2_sec_group
 end

--- a/script/update_base_ruby_box.rb
+++ b/script/update_base_ruby_box.rb
@@ -9,11 +9,14 @@ require 'trollop'
 require 'json'
 
 require_relative 'lib/mocks'
+require_relative 'lib/aws_config'
 
 # Fog.mock!
 # mock_aws(ec2_instance_name: "RitesProduction")
 
 ec2 = ::Fog::Compute[:aws]
+
+config = aws_config_defaults
 
 start = Time.now
 puts "*** creating new server"
@@ -32,13 +35,14 @@ server = ec2.servers.create({
   flavor_id: 'c4.large',
 
   # Need to put it in a VPC
-  subnet_id: 'subnet-7fb16326',
+  subnet_id: config['subnet_id'],
 
   # this doesn't mater perhaps we can leave it blank, it does need to be
   # in the east though so we get the right ami and the saved image is in the right place
   # :availability_zone => config['availability_zone'],
 
   # needs an explicity security group id because it is in a VPC
+  # this is just using an existing security group that has ssh enabled
   security_group_ids: ['sg-53f1a237'],
   tags: {
     "Name"     => "base-ruby-box",

--- a/script/update_base_ruby_box.rb
+++ b/script/update_base_ruby_box.rb
@@ -20,18 +20,26 @@ puts "*** creating new server"
 server = ec2.servers.create({
   key_name: 'genigames',
   # the latest version can be looked up here:
-  # http://alestic.com/
+  # http://cloud-images.ubuntu.com/locator/ec2/
   # ideally this could be automatically pulled from here:
   # https://help.ubuntu.com/community/UEC/Images#Machine_Consumable_Ubuntu_Cloud_Guest_images_Availability_Data
-  image_id: 'ami-9c78c0f5',
+  # This is 12.04, amd64, hvm:ebs
+  image_id: 'ami-f905f692',
+
   # because we are building ruby lets make this big so it is fast
   # it is likely that building is a single threaded thing so what matter is the single core
   # performance
-  flavor_id: 'm2.xlarge',
+  flavor_id: 'c4.large',
+
+  # Need to put it in a VPC
+  subnet_id: 'subnet-7fb16326',
+
   # this doesn't mater perhaps we can leave it blank, it does need to be
   # in the east though so we get the right ami and the saved image is in the right place
   # :availability_zone => config['availability_zone'],
-  groups: 'default', # should use a default here
+
+  # needs an explicity security group id because it is in a VPC
+  security_group_ids: ['sg-53f1a237'],
   tags: {
     "Name"     => "base-ruby-box",
     "Contacts" => 'Scott',  # <- should set this based on the current user running this script

--- a/site-cookbooks/base-ruby-box/metadata.json
+++ b/site-cookbooks/base-ruby-box/metadata.json
@@ -3,6 +3,10 @@
   "platforms": {
     "ubuntu": ">= 10.0.0"
   },
+  "dependencies": {
+    "apt": ">= 0.0.0",
+    "chef-ruby": ">= 0.0.0"
+  },
   "recipes": {
     "base-ruby-box": "setup initial ruby box"
   }

--- a/site-cookbooks/base-ruby-box/recipes/default.rb
+++ b/site-cookbooks/base-ruby-box/recipes/default.rb
@@ -13,6 +13,7 @@ include_recipe "chef-ruby::gem_package"
 # patch applied above.
 gem_package "ohai" do 
   action :install
+  version "7.4.1"
   gem_binary('/usr/local/bin/gem')	
 end
 

--- a/site-cookbooks/cc-monit/metadata.json
+++ b/site-cookbooks/cc-monit/metadata.json
@@ -3,6 +3,9 @@
   "platforms": {
     "ubuntu": ">= 10.0.0"
   },
+  "dependencies": {
+  	"monit": "> 0.0.0"
+  },
   "recipes": {
     "cc-monit": "Configure monit for CC portals"
   }

--- a/site-cookbooks/cc-rails-portal-server/metadata.json
+++ b/site-cookbooks/cc-rails-portal-server/metadata.json
@@ -3,6 +3,11 @@
   "platforms": {
     "ubuntu": ">= 10.0.0"
   },
+  "dependencies": {
+    "imagemagick": ">= 0.0.0",
+    "cc-rails": ">= 0.0.0",
+    "cc-solr": ">= 0.0.0"
+  },
   "recipes": {
     "cc-rails-portal-server": "extra stuff to setup rails-portal-server"
   }

--- a/site-cookbooks/cc-rails/metadata.json
+++ b/site-cookbooks/cc-rails/metadata.json
@@ -3,6 +3,11 @@
   "platforms": {
     "ubuntu": ">= 10.0.0"
   },
+  "dependencies": {
+  	"apache2": "> 0.0.0",
+  	"git": "> 0.0.0",
+  	"passenger_apache2": "> 0.0.0"
+  },
   "recipes": {
     "cc-rails": "setup a generic rails server"
   }


### PR DESCRIPTION
The ubuntu update seems to not have caused any problems so. We were already using ubunut 12.04, this ami is just a newer version of 12.04 with newer packages.

The only change chef 11 seems to require is explicit dependencies in the recipe metadata.  Chef 11 can be used locally if you update your littlechef pip package to 1.8.0. 

The VPC changes require some explicit security groups as well as specifying subnet_id and vpc_id in various places.

After the the new base box was built, I update the ami used by the create scripts to be this new ami.

@knowuh if you have time it is probably worthwhile if I walk through this with you since I think well be using chef for at least another month. 
