### PR TITLE
Change learn production site url to use https

### DIFF
--- a/roles/learn-production.json
+++ b/roles/learn-production.json
@@ -17,7 +17,7 @@
             "google_analytics_account": "UA-6899787-46"
         },
         "cc_rails_portal": {
-            "site_url": "http://learn.concord.org",
+            "site_url": "https://learn.concord.org",
             "authoring_site_url": "//authoring.concord.org",
             "s3_bucket": "nextgen-production",
             "stage": "production"


### PR DESCRIPTION
This change is so that the paperclip settings pickup the https protocol to use in the generated s3 urls
